### PR TITLE
Add IRkernel (R) to CI matrix

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -33,10 +33,10 @@ jobs:
           - name: irkernel
             install: |
               python -m pip install jupyter
-              JUPYTER_PATH=$(which jupyter)
-              echo "Jupyter path: $JUPYTER_PATH"
+              jupyter kernelspec --version
               Rscript -e "install.packages('IRkernel', repos='https://cloud.r-project.org')"
-              Rscript -e "print(Sys.getenv('PATH')); system('which jupyter'); IRkernel::installspec()"
+              Rscript -e "system2('jupyter', c('kernelspec', '--version'), stdout=TRUE, stderr=TRUE)"
+              Rscript -e "IRkernel::installspec()"
             kernel-name: ir
 
     steps:


### PR DESCRIPTION
## Summary

Adds the R kernel (IRkernel) to the conformance test matrix.

- Uses `r-lib/actions/setup-r@v2` for R installation
- Installs IRkernel from CRAN
- Kernel name: `ir`

## Test plan
- [ ] IRkernel tests run in CI
- [ ] Conformance matrix includes IR results