### PR TITLE
Add Ark (Posit R kernel) to CI matrix

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -34,7 +34,7 @@ jobs:
             install: |
               # Download Ark binary from GitHub releases
               curl -fsSL -o ark.zip https://github.com/posit-dev/ark/releases/download/0.1.232/ark-0.1.232-linux-x64.zip
-              unzip ark.zip
+              unzip -o ark.zip
               chmod +x ark
               sudo mv ark /usr/local/bin/
               # Install kernel


### PR DESCRIPTION
## Summary

Adds Ark, the Posit R kernel, to the conformance test matrix. Ark is a Rust-based R kernel that provides better Jupyter protocol support than IRkernel.

### Installation
- Downloads prebuilt binary from GitHub releases (v0.1.232)
- Uses `r-lib/actions/setup-r@v2` for R 4.4
- Installs jupyter via pip for kernel registration

### Why Ark over IRkernel?
- Ark is written in Rust and has better protocol conformance
- No complex Python-R environment setup issues
- Actively maintained by Posit

## Test plan
- [ ] Ark tests run in CI
- [ ] Conformance matrix includes Ark results