### PR TITLE
Use runtimed fix branch for Ark kernel compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ name = "jupyter-kernel-test"
 path = "src/main.rs"
 
 [dependencies]
-jupyter-protocol = { git = "https://github.com/runtimed/runtimed", branch = "main" }
-runtimelib = { git = "https://github.com/runtimed/runtimed", branch = "main", features = ["tokio-runtime", "ring"] }
+# Use the fix branch until PR #282 is merged
+jupyter-protocol = { git = "https://github.com/runtimed/runtimed", branch = "fix-optional-kernel-info-fields" }
+runtimelib = { git = "https://github.com/runtimed/runtimed", branch = "fix-optional-kernel-info-fields", features = ["tokio-runtime", "ring"] }
 
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## Summary

Uses the runtimed PR #282 branch which adds `#[serde(default)]` to optional fields in KernelInfoReply. This fixes the Ark kernel test failures where deserialization was failing due to missing `implementation` field.

## Related

- runtimed/runtimed#282 - upstream fix

## Test Plan

- CI should now successfully parse Ark kernel's kernel_info_reply
- All other kernels should continue to work as before