### PR TITLE
Use runtimed fix for Almond date field compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ name = "jupyter-kernel-test"
 path = "src/main.rs"
 
 [dependencies]
-jupyter-protocol = { git = "https://github.com/runtimed/runtimed", branch = "main" }
-runtimelib = { git = "https://github.com/runtimed/runtimed", branch = "main", features = ["tokio-runtime", "ring"] }
+# Use fix branch until PR #283 is merged (date field optional for Almond)
+jupyter-protocol = { git = "https://github.com/runtimed/runtimed", branch = "fix-optional-header-date" }
+runtimelib = { git = "https://github.com/runtimed/runtimed", branch = "fix-optional-header-date", features = ["tokio-runtime", "ring"] }
 
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## Summary

Use runtimed PR #283 branch which makes the header `date` field optional. Almond kernel doesn't provide this field in message headers.

## Related

- runtimed/runtimed#283 - upstream fix

## Test Plan

- CI should now successfully run tests against Almond kernel