### PR TITLE
Add IJulia (Julia kernel) to CI matrix

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -47,6 +47,9 @@ jobs:
               ./coursier launch almond -- --install
               rm -f coursier
             kernel-name: scala
+          - name: ijulia
+            install: julia -e 'using Pkg; Pkg.add("IJulia"); using IJulia'
+            kernel-name: julia-1.11
 
     steps:
       - uses: actions/checkout@v4
@@ -72,6 +75,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      - name: Set up Julia
+        if: matrix.kernel.name == 'ijulia'
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: '1.11'
 
       - name: Install jupyter for Ark
         if: matrix.kernel.name == 'ark'


### PR DESCRIPTION
## Summary

Add IJulia kernel to the conformance test suite:
- Install via Julia package manager (`Pkg.add("IJulia")`)
- Set up Julia 1.11 using julia-actions/setup-julia

## Test Plan

- CI should run tests against IJulia kernel
- Julia snippets already exist in the test suite