### PR TITLE
Revert to runtimed main branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,8 @@ name = "jupyter-kernel-test"
 path = "src/main.rs"
 
 [dependencies]
-# Use fix branch until PR #283 is merged (date field optional for Almond)
-jupyter-protocol = { git = "https://github.com/runtimed/runtimed", branch = "fix-optional-header-date" }
-runtimelib = { git = "https://github.com/runtimed/runtimed", branch = "fix-optional-header-date", features = ["tokio-runtime", "ring"] }
+jupyter-protocol = { git = "https://github.com/runtimed/runtimed", branch = "main" }
+runtimelib = { git = "https://github.com/runtimed/runtimed", branch = "main", features = ["tokio-runtime", "ring"] }
 
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## Summary

Revert to using runtimed main branch. The `date` field in message headers is required by the Jupyter messaging protocol spec - Almond not providing it is a kernel bug, not something to work around in runtimed.

Almond will now show as failing tests due to protocol non-conformance, which is the correct behavior.

## Test Plan

- CI should pass for all kernels except Almond (which will show protocol errors)