### PR TITLE
Cache evcxr_jupyter binary separately

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,7 +22,13 @@ jobs:
             install: pip install ipykernel && python -m ipykernel install --user
             kernel-name: python3
           - name: evcxr
-            install: cargo install --locked evcxr_jupyter && evcxr_jupyter --install
+            install: |
+              if [ -f ~/.cargo/bin/evcxr_jupyter ]; then
+                echo "evcxr_jupyter found in cache"
+              else
+                cargo install --locked evcxr_jupyter
+              fi
+              evcxr_jupyter --install
             kernel-name: rust
           - name: deno
             install: |
@@ -86,15 +92,26 @@ jobs:
         if: matrix.kernel.name == 'ark'
         run: python -m pip install jupyter
 
-      - name: Cache cargo
+      - name: Cache cargo (test suite)
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/
             ~/.cargo/git/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache evcxr
+        if: matrix.kernel.name == 'evcxr'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/evcxr*
+            ~/.cargo/registry/
+            ~/.cargo/git/
+          key: ${{ runner.os }}-evcxr-0.21.1
+          restore-keys: |
+            ${{ runner.os }}-evcxr-
 
       - name: Install kernel
         run: ${{ matrix.kernel.install }}


### PR DESCRIPTION
## Summary

Optimize evcxr test performance by caching the compiled binary with a stable, version-specific cache key.

**Changes:**
- Add dedicated cache for evcxr with key based on version (0.21.1)
- Skip `cargo install` if `evcxr_jupyter` binary already in cache
- Separate from test suite cargo cache to avoid invalidation on unrelated changes

First run will still compile (~5-10 min), but subsequent runs reuse cached binary. Prevents unnecessary recompilation of evcxr on every test run.

_PR submitted by @rgbkrk's agent, Quill_