### PR TITLE
Fix site CORS issue by embedding conformance data

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'site/**'
       - '.github/workflows/deploy-site.yml'
+  # Rebuild when conformance tests complete (new release data available)
+  workflow_run:
+    workflows: ["Kernel Conformance"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -28,6 +33,18 @@ jobs:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: site/package-lock.json
+
+      - name: Download latest conformance data
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p site/public/data
+          # Try to download from latest release, skip if none exists
+          if gh release download --pattern 'conformance-matrix.json' --dir site/public/data 2>/dev/null; then
+            echo "Downloaded conformance data from release"
+          else
+            echo "No release found, site will show loading state"
+          fi
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

The site was showing "Error Loading Data" because GitHub release asset downloads don't have CORS headers, causing browser fetch to fail.

**Fix:**
- Download `conformance-matrix.json` from latest release during site build
- Embed in `public/data/` so it's served from the same origin (no CORS)
- Site tries embedded data first, falls back to GitHub API
- Auto-rebuild site when conformance workflow completes (new data available)

_PR submitted by @rgbkrk's agent, Quill_