### PR TITLE
Add failure summary and auto-expand failing tiers

### DIFF
--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Header } from '@/components/Header';
 import { KernelCard } from '@/components/KernelCard';
 import { TierBreakdown } from '@/components/TierBreakdown';
+import { FailureSummary } from '@/components/FailureSummary';
 import { SummaryTable, DetailedMatrix } from '@/components/ConformanceMatrix';
 import { useConformanceData } from '@/hooks/useConformanceData';
 import { ArrowLeft, Table2, Grid3X3, LayoutGrid, Github, AlertCircle } from 'lucide-react';
@@ -118,6 +119,8 @@ function App() {
                 {selectedKernel.protocol_version}
               </p>
             </div>
+
+            <FailureSummary report={selectedKernel} />
 
             <TierBreakdown report={selectedKernel} />
           </main>

--- a/site/src/components/FailureSummary.tsx
+++ b/site/src/components/FailureSummary.tsx
@@ -1,0 +1,107 @@
+import { AlertTriangle, XCircle, CheckCircle2, ChevronRight } from 'lucide-react';
+import type { KernelReport, TestRecord } from '@/types/report';
+import { getPassedCount, getTotalCount } from '@/types/report';
+
+interface FailureSummaryProps {
+  report: KernelReport;
+}
+
+// Group failures by their reason pattern
+function groupFailuresByReason(report: KernelReport): Map<string, TestRecord[]> {
+  const groups = new Map<string, TestRecord[]>();
+
+  for (const test of report.results) {
+    if (test.result.status === 'fail') {
+      const reason = test.result.reason || 'Unknown error';
+      // Normalize common patterns
+      const key = reason.includes('Timeout') ? 'Timeout' : reason;
+      const existing = groups.get(key) || [];
+      existing.push(test);
+      groups.set(key, existing);
+    }
+  }
+
+  return groups;
+}
+
+export function FailureSummary({ report }: FailureSummaryProps) {
+  const passed = getPassedCount(report);
+  const total = getTotalCount(report);
+  const failed = total - passed;
+  const percentage = total > 0 ? Math.round((passed / total) * 100) : 0;
+
+  // All passing - show success state
+  if (failed === 0) {
+    return (
+      <div className="rounded-lg border border-ctp-green/30 bg-ctp-green/5 p-4 mb-6">
+        <div className="flex items-center gap-3">
+          <CheckCircle2 className="h-6 w-6 text-ctp-green flex-shrink-0" />
+          <div>
+            <h3 className="font-medium text-ctp-green">All tests passing</h3>
+            <p className="text-sm text-ctp-subtext0 mt-0.5">
+              {passed}/{total} tests pass ({percentage}%)
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const failureGroups = groupFailuresByReason(report);
+  const sortedGroups = Array.from(failureGroups.entries()).sort(
+    (a, b) => b[1].length - a[1].length
+  );
+
+  // Determine severity
+  const isCritical = percentage < 50;
+  const borderColor = isCritical ? 'border-ctp-red/30' : 'border-ctp-peach/30';
+  const bgColor = isCritical ? 'bg-ctp-red/5' : 'bg-ctp-peach/5';
+  const iconColor = isCritical ? 'text-ctp-red' : 'text-ctp-peach';
+  const Icon = isCritical ? XCircle : AlertTriangle;
+
+  return (
+    <div className={`rounded-lg border ${borderColor} ${bgColor} p-4 mb-6`}>
+      <div className="flex items-start gap-3">
+        <Icon className={`h-6 w-6 ${iconColor} flex-shrink-0 mt-0.5`} />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline justify-between gap-4">
+            <h3 className={`font-medium ${iconColor}`}>
+              {failed} test{failed !== 1 ? 's' : ''} failing
+            </h3>
+            <span className="text-sm text-ctp-subtext0 tabular-nums">
+              {passed}/{total} passing ({percentage}%)
+            </span>
+          </div>
+
+          {/* Grouped failure reasons */}
+          <div className="mt-3 space-y-2">
+            {sortedGroups.map(([reason, tests]) => (
+              <div key={reason} className="text-sm">
+                <div className="flex items-center gap-2 text-ctp-text">
+                  <ChevronRight className="h-3.5 w-3.5 text-ctp-overlay0" />
+                  <span className="font-medium">{reason}</span>
+                  <span className="text-ctp-subtext0">({tests.length})</span>
+                </div>
+                <div className="ml-5 mt-1 text-xs text-ctp-subtext0">
+                  {tests
+                    .slice(0, 3)
+                    .map((t) => t.name)
+                    .join(', ')}
+                  {tests.length > 3 && ` +${tests.length - 3} more`}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Actionable hint for timeout issues */}
+          {failureGroups.has('Timeout') && (
+            <p className="mt-3 text-xs text-ctp-subtext0 border-t border-ctp-surface0 pt-3">
+              Timeout failures often indicate the kernel doesn't implement certain message types.
+              Check if these messages are supported in your kernel.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/site/src/components/TierBreakdown.tsx
+++ b/site/src/components/TierBreakdown.tsx
@@ -24,8 +24,17 @@ function getScoreColor(percentage: number): string {
 }
 
 export function TierBreakdown({ report }: TierBreakdownProps) {
+  // Default open tiers that have failures
+  const tiersWithFailures = TIERS.filter((tier) => {
+    const results = getTierResults(report, tier);
+    return results.some((t) => t.result.status === 'fail');
+  });
+
+  // If no failures, default to tier1_basic
+  const defaultOpen = tiersWithFailures.length > 0 ? tiersWithFailures : ['tier1_basic'];
+
   return (
-    <Accordion type="multiple" className="w-full space-y-2" defaultValue={['tier1_basic']}>
+    <Accordion type="multiple" className="w-full space-y-2" defaultValue={defaultOpen}>
       {TIERS.map((tier) => {
         const results = getTierResults(report, tier);
         if (results.length === 0) return null;


### PR DESCRIPTION
## Summary

- Add FailureSummary component showing grouped failures at the top of kernel detail pages
- Green banner for 100% passing kernels, red/orange for failures based on severity
- Group failures by reason pattern (e.g., all "Timeout" failures together)
- Show which specific tests are failing with counts
- Auto-expand accordion tiers that have failures instead of defaulting to tier1
- Actionable hint for timeout issues

## Test plan

- [x] View a kernel with failures (e.g., rust/evcxr) - should see failure summary
- [x] View a kernel with all passing (e.g., python3) - should see green success banner
- [x] Verify failing tiers auto-expand on page load
- [x] Check that failure reasons are properly grouped

_PR submitted by @rgbkrk's agent, Quill_