### PR TITLE
Generate partial reports for kernel startup failures

### DIFF
--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -6,6 +6,7 @@ import { KernelCard } from '@/components/KernelCard';
 import { TierBreakdown } from '@/components/TierBreakdown';
 import { FailureSummary } from '@/components/FailureSummary';
 import { SummaryTable, DetailedMatrix } from '@/components/ConformanceMatrix';
+import { hasStartupError } from '@/types/report';
 import { useConformanceData } from '@/hooks/useConformanceData';
 import { ArrowLeft, Table2, Grid3X3, LayoutGrid, Github, AlertCircle } from 'lucide-react';
 import type { KernelReport } from '@/types/report';
@@ -122,7 +123,8 @@ function App() {
 
             <FailureSummary report={selectedKernel} />
 
-            <TierBreakdown report={selectedKernel} />
+            {/* Only show tier breakdown if kernel started successfully */}
+            {!hasStartupError(selectedKernel) && <TierBreakdown report={selectedKernel} />}
           </main>
         </div>
       </TooltipProvider>

--- a/site/src/components/FailureSummary.tsx
+++ b/site/src/components/FailureSummary.tsx
@@ -1,6 +1,6 @@
-import { AlertTriangle, XCircle, CheckCircle2, ChevronRight } from 'lucide-react';
+import { AlertTriangle, XCircle, CheckCircle2, ChevronRight, Skull } from 'lucide-react';
 import type { KernelReport, TestRecord } from '@/types/report';
-import { getPassedCount, getTotalCount } from '@/types/report';
+import { getPassedCount, getTotalCount, hasStartupError } from '@/types/report';
 
 interface FailureSummaryProps {
   report: KernelReport;
@@ -25,6 +25,30 @@ function groupFailuresByReason(report: KernelReport): Map<string, TestRecord[]> 
 }
 
 export function FailureSummary({ report }: FailureSummaryProps) {
+  // Check for startup error first - this is a critical failure
+  if (hasStartupError(report)) {
+    return (
+      <div className="rounded-lg border border-ctp-red/50 bg-ctp-red/10 p-4 mb-6">
+        <div className="flex items-start gap-3">
+          <Skull className="h-6 w-6 text-ctp-red flex-shrink-0 mt-0.5" />
+          <div className="flex-1 min-w-0">
+            <h3 className="font-medium text-ctp-red">Kernel failed during startup</h3>
+            <p className="text-sm text-ctp-subtext0 mt-1">
+              The kernel could not complete initialization. No tests were run.
+            </p>
+            <div className="mt-3 p-3 rounded bg-ctp-surface0/50 font-mono text-sm text-ctp-red">
+              {report.startup_error}
+            </div>
+            <p className="mt-3 text-xs text-ctp-subtext0">
+              This usually indicates a fundamental protocol compatibility issue.
+              Check that the kernel sends valid Jupyter protocol messages.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   const passed = getPassedCount(report);
   const total = getTotalCount(report);
   const failed = total - passed;

--- a/site/src/types/report.ts
+++ b/site/src/types/report.ts
@@ -113,6 +113,8 @@ export interface KernelReport {
   timestamp: string;
   /** Total duration of test run in milliseconds */
   total_duration: number;
+  /** Error that prevented tests from running (e.g., kernel startup failed) */
+  startup_error?: string;
 }
 
 /** Matrix of conformance results across multiple kernels */
@@ -159,4 +161,9 @@ export function getAllTestNames(matrix: ConformanceMatrix): string[] {
     }
   }
   return Array.from(names).sort();
+}
+
+/** Check if a kernel failed during startup before tests could run */
+export function hasStartupError(report: KernelReport): boolean {
+  return report.startup_error !== undefined && report.startup_error !== null;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,25 +120,24 @@ async fn main() -> anyhow::Result<()> {
             }
         };
 
-        match run_conformance_suite(kernelspec, &tiers, timeout, &tests).await {
-            Ok(report) => {
-                if args.verbose {
-                    eprintln!(
-                        "  Completed: {}/{} passed",
-                        report.passed(),
-                        report.total()
-                    );
-                }
-                reports.push(report);
-            }
-            Err(e) => {
-                eprintln!("Error testing kernel '{}': {}", kernel_name, e);
+        let report = run_conformance_suite(kernelspec, &tiers, timeout, &tests).await;
+
+        if args.verbose {
+            if report.has_startup_error() {
+                eprintln!("  Startup failed: {}", report.startup_error.as_ref().unwrap());
+            } else {
+                eprintln!(
+                    "  Completed: {}/{} passed",
+                    report.passed(),
+                    report.total()
+                );
             }
         }
+        reports.push(report);
     }
 
     if reports.is_empty() {
-        eprintln!("No successful test runs");
+        eprintln!("No kernels tested");
         std::process::exit(1);
     }
 


### PR DESCRIPTION
## Summary

Kernels that fail during startup (like Almond with its missing `date` field) now produce partial reports instead of being silently omitted.

**Rust changes:**
- Add `startup_error` field to `KernelReport` for early failures
- Change `run_conformance_suite` to always return a report (no more `Result`)
- When startup fails, generate a report with the error and a single failed `kernel_startup` test

**Site changes:**
- Add `startup_error` to TypeScript types
- Create `FailureSummary` component with special handling for startup errors (skull icon, error message display)
- Auto-expand failing tiers in TierBreakdown
- Conditionally hide tier breakdown when kernel has startup error

## Why this matters

Before: Almond doesn't appear in conformance matrix at all
After: Almond appears with 0% score and clear error: "Protocol error: missing field `date`"

This makes broken kernels visible and provides actionable feedback.

## Test plan

- [ ] Build and run test suite against a kernel that fails startup
- [ ] Verify report JSON includes `startup_error` field
- [ ] Check site renders startup error prominently
- [ ] Verify normal kernels still work correctly

_PR submitted by @rgbkrk's agent, Quill_