### PR TITLE
Fix footer and header layout

### DIFF
--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -134,10 +134,10 @@ function App() {
   // Main matrix view
   return (
     <TooltipProvider>
-      <div className="min-h-screen bg-ctp-base">
+      <div className="min-h-screen bg-ctp-base flex flex-col">
         <Header generatedAt={data.generated_at} commitSha={data.commit_sha} />
 
-        <main className="container mx-auto px-4 py-8">
+        <main className="container mx-auto px-4 py-8 flex-1">
           <div className="space-y-6">
             {/* Simple tab buttons */}
             <div className="flex gap-1 text-sm">
@@ -197,19 +197,19 @@ function App() {
           </div>
         </main>
 
-        <footer className="border-t border-ctp-surface0 mt-12 bg-ctp-mantle">
-          <div className="container mx-auto px-4 py-6 text-center text-sm text-ctp-subtext0">
+        <footer className="border-t border-ctp-surface0 bg-ctp-mantle">
+          <div className="container mx-auto px-4 py-6 flex items-center justify-center gap-2 text-sm text-ctp-subtext0">
             <a
               href="https://github.com/runtimed/kernel-testbed"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 hover:text-ctp-mauve transition-colors"
+              className="flex items-center gap-2 hover:text-ctp-mauve transition-colors"
             >
               <Github className="h-4 w-4" />
               kernel-testbed
             </a>
-            <span className="mx-2">•</span>
-            Jupyter kernel protocol conformance testing
+            <span>•</span>
+            <span>Jupyter kernel protocol conformance testing</span>
           </div>
         </footer>
       </div>

--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@/components/ui/badge';
 import { FlaskConical, GitCommit, Calendar } from 'lucide-react';
 
 interface HeaderProps {
@@ -36,10 +35,10 @@ export function Header({ generatedAt, commitSha }: HeaderProps) {
           </div>
           <div className="flex flex-col items-start sm:items-end gap-2">
             {formattedDate && (
-              <Badge variant="outline" className="text-xs gap-1.5 bg-ctp-surface0/50 border-ctp-surface1">
+              <span className="text-xs text-ctp-subtext0 flex items-center gap-1.5">
                 <Calendar className="h-3 w-3 text-ctp-blue" />
-                {formattedDate}
-              </Badge>
+                Last tested {formattedDate}
+              </span>
             )}
             {commitSha && (
               <a


### PR DESCRIPTION
## Summary

- Make footer sticky to bottom with flexbox layout
- Change date display to "Last tested {date}" for clarity
- Align footer items vertically with flex centering
- Remove unused Badge import

_PR submitted by @rgbkrk's agent, Quill_