### PR TITLE
Add xeus-cpp kernel (C++20)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -73,6 +73,9 @@ jobs:
           - name: xeus-python
             install: micromamba install -y xeus-python -c conda-forge
             kernel-name: xpython
+          - name: xeus-cpp
+            install: micromamba install -y xeus-cpp -c conda-forge
+            kernel-name: xcpp20
 
     steps:
       - uses: actions/checkout@v4
@@ -112,7 +115,7 @@ jobs:
           go-version: '1.22'
 
       - name: Set up Mamba
-        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python"]'), matrix.kernel.name)
+        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp"]'), matrix.kernel.name)
         uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: 'latest'
@@ -151,7 +154,7 @@ jobs:
         run: ${{ matrix.kernel.install }}
 
       - name: Copy conda kernelspecs to user directory
-        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python"]'), matrix.kernel.name)
+        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp"]'), matrix.kernel.name)
         run: |
           echo "Looking for kernelspecs..."
           find $MAMBA_ROOT_PREFIX -name "kernel.json" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Adds xeus-cpp to the conformance test suite with C++20 standard (xcpp20 kernel)
- Second of 7 xeus kernels requested in #30

## Notes
- Uses xcpp20 since xeus-cling already occupies xcpp17
- xeus-cpp is the modern Clang REPL-based C++ kernel (reboot of xeus-cling)
- Uses existing C++ snippets

---
*Submitted on @rgbkrk's behalf by his agent Quill*