### PR TITLE
Add xeus-sqlite kernel

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -76,6 +76,9 @@ jobs:
           - name: xeus-cpp
             install: micromamba install -y xeus-cpp -c conda-forge
             kernel-name: xcpp20
+          - name: xeus-sqlite
+            install: micromamba install -y xeus-sqlite -c conda-forge
+            kernel-name: xsqlite
 
     steps:
       - uses: actions/checkout@v4
@@ -115,7 +118,7 @@ jobs:
           go-version: '1.22'
 
       - name: Set up Mamba
-        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp"]'), matrix.kernel.name)
+        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp", "xeus-sqlite"]'), matrix.kernel.name)
         uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: 'latest'
@@ -154,7 +157,7 @@ jobs:
         run: ${{ matrix.kernel.install }}
 
       - name: Copy conda kernelspecs to user directory
-        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp"]'), matrix.kernel.name)
+        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp", "xeus-sqlite"]'), matrix.kernel.name)
         run: |
           echo "Looking for kernelspecs..."
           find $MAMBA_ROOT_PREFIX -name "kernel.json" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Adds xeus-sqlite to the conformance test suite
- Third of 7 xeus kernels requested in #30

## Notes
- Uses existing SQL snippets
- xsqlite kernel (SQLite-specific, vs xsql which uses SOCI)

---
*Submitted on @rgbkrk's behalf by his agent Quill*