### PR TITLE
Add xeus-r kernel

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -79,6 +79,9 @@ jobs:
           - name: xeus-sqlite
             install: micromamba install -y xeus-sqlite -c conda-forge
             kernel-name: xsqlite
+          - name: xeus-r
+            install: micromamba install -y xeus-r -c conda-forge
+            kernel-name: xr
 
     steps:
       - uses: actions/checkout@v4
@@ -118,7 +121,7 @@ jobs:
           go-version: '1.22'
 
       - name: Set up Mamba
-        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp", "xeus-sqlite"]'), matrix.kernel.name)
+        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp", "xeus-sqlite", "xeus-r"]'), matrix.kernel.name)
         uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: 'latest'
@@ -157,7 +160,7 @@ jobs:
         run: ${{ matrix.kernel.install }}
 
       - name: Copy conda kernelspecs to user directory
-        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp", "xeus-sqlite"]'), matrix.kernel.name)
+        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp", "xeus-sqlite", "xeus-r"]'), matrix.kernel.name)
         run: |
           echo "Looking for kernelspecs..."
           find $MAMBA_ROOT_PREFIX -name "kernel.json" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Adds xeus-r (xr kernel) to the conformance test suite
- Fourth of 7 xeus kernels requested in #30

## Notes
- Uses existing R snippets
- xeus-based R kernel (alternative to IRkernel/ark)

---
*Submitted on @rgbkrk's behalf by his agent Quill*