### PR TITLE
Add xeus-lua kernel

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -82,6 +82,9 @@ jobs:
           - name: xeus-r
             install: micromamba install -y xeus-r -c conda-forge
             kernel-name: xr
+          - name: xeus-lua
+            install: micromamba install -y xeus-lua -c conda-forge
+            kernel-name: xlua
 
     steps:
       - uses: actions/checkout@v4
@@ -121,7 +124,7 @@ jobs:
           go-version: '1.22'
 
       - name: Set up Mamba
-        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp", "xeus-sqlite", "xeus-r"]'), matrix.kernel.name)
+        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp", "xeus-sqlite", "xeus-r", "xeus-lua"]'), matrix.kernel.name)
         uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: 'latest'
@@ -160,7 +163,7 @@ jobs:
         run: ${{ matrix.kernel.install }}
 
       - name: Copy conda kernelspecs to user directory
-        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp", "xeus-sqlite", "xeus-r"]'), matrix.kernel.name)
+        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp", "xeus-sqlite", "xeus-r", "xeus-lua"]'), matrix.kernel.name)
         run: |
           echo "Looking for kernelspecs..."
           find $MAMBA_ROOT_PREFIX -name "kernel.json" 2>/dev/null || true

--- a/src/snippets.rs
+++ b/src/snippets.rs
@@ -52,6 +52,7 @@ impl LanguageSnippets {
             "scala" => Self::scala(),
             "c++" | "cpp" => Self::cpp(),
             "sql" => Self::sql(),
+            "lua" => Self::lua(),
             _ => Self::generic(&lang),
         }
     }
@@ -267,6 +268,27 @@ xcpp::display(h);"#,
             // xeus-sql displays query results as tables natively
             display_data_code: "SELECT 1 AS col1, 2 AS col2, 3 AS col3;",
             update_display_data_code: "-- SQL doesn't support update_display_data",
+        }
+    }
+
+    fn lua() -> Self {
+        // Lua scripting language
+        Self {
+            language: "lua".to_string(),
+            print_hello: "print('hello')",
+            print_stderr: "io.stderr:write('error\\n')",
+            simple_expr: "return 1 + 1",
+            simple_expr_result: "2",
+            incomplete_code: "function foo(",
+            complete_code: "x = 1",
+            syntax_error: "function function",
+            input_prompt: "-- Lua stdin varies by kernel",
+            sleep_code: "-- Lua sleep requires os.execute or socket",
+            completion_var: "test_variable_for_completion",
+            completion_setup: "test_variable_for_completion = 42",
+            completion_prefix: "test_variable_for_",
+            display_data_code: "print('no rich display')",
+            update_display_data_code: "-- Lua doesn't support update_display_data",
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds xeus-lua (xlua kernel) to the conformance test suite
- Sixth of 7 xeus kernels requested in #30

## Changes
- Added Lua language snippets (`src/snippets.rs`)
- Added xeus-lua to CI workflow

---
*Submitted on @rgbkrk's behalf by his agent Quill*