### PR TITLE
Add 10-minute timeout to kernel test jobs

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -14,6 +14,7 @@ jobs:
   test-kernel:
     name: Test ${{ matrix.kernel.name }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
Adds `timeout-minutes: 10` to the test-kernel job to prevent hung tests from running indefinitely.

## Context
- xeus-octave tests were hanging for 30+ minutes
- This ensures CI fails fast rather than waiting for GitHub's default 6-hour timeout

---
*Submitted on @rgbkrk's behalf by his agent Quill*