### PR TITLE
Add xeus-octave kernel

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -96,6 +96,9 @@ jobs:
               pixi run -e default build
               pixi run -e default install
             kernel-name: xhaskell
+          - name: xeus-octave
+            install: micromamba install -y xeus-octave -c conda-forge
+            kernel-name: xoctave
 
     steps:
       - uses: actions/checkout@v4
@@ -135,7 +138,7 @@ jobs:
           go-version: '1.22'
 
       - name: Set up Mamba
-        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp", "xeus-sqlite", "xeus-r", "xeus-lua"]'), matrix.kernel.name)
+        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp", "xeus-sqlite", "xeus-r", "xeus-lua", "xeus-octave"]'), matrix.kernel.name)
         uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: 'latest'
@@ -174,7 +177,7 @@ jobs:
         run: ${{ matrix.kernel.install }}
 
       - name: Copy conda kernelspecs to user directory
-        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp", "xeus-sqlite", "xeus-r", "xeus-lua"]'), matrix.kernel.name)
+        if: contains(fromJson('["xeus-cling", "xeus-sql", "xeus-python", "xeus-cpp", "xeus-sqlite", "xeus-r", "xeus-lua", "xeus-octave"]'), matrix.kernel.name)
         run: |
           echo "Looking for kernelspecs..."
           find $MAMBA_ROOT_PREFIX -name "kernel.json" 2>/dev/null || true
@@ -188,6 +191,10 @@ jobs:
           fi
           ls -la ~/.local/share/jupyter/kernels/ || true
 
+      - name: Install Xvfb for xeus-octave
+        if: matrix.kernel.name == 'xeus-octave'
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
       - name: Build test suite
         run: cargo build --release
 
@@ -196,13 +203,24 @@ jobs:
 
       - name: Run conformance tests
         run: |
-          ./target/release/jupyter-kernel-test ${{ matrix.kernel.kernel-name }} \
-            --format json \
-            --output ${{ matrix.kernel.name }}-report.json
+          if [ "${{ matrix.kernel.name }}" = "xeus-octave" ]; then
+            xvfb-run -a ./target/release/jupyter-kernel-test ${{ matrix.kernel.kernel-name }} \
+              --format json \
+              --output ${{ matrix.kernel.name }}-report.json
+          else
+            ./target/release/jupyter-kernel-test ${{ matrix.kernel.kernel-name }} \
+              --format json \
+              --output ${{ matrix.kernel.name }}-report.json
+          fi
         continue-on-error: true
 
       - name: Display results
-        run: ./target/release/jupyter-kernel-test ${{ matrix.kernel.kernel-name }} || true
+        run: |
+          if [ "${{ matrix.kernel.name }}" = "xeus-octave" ]; then
+            xvfb-run -a ./target/release/jupyter-kernel-test ${{ matrix.kernel.kernel-name }} || true
+          else
+            ./target/release/jupyter-kernel-test ${{ matrix.kernel.kernel-name }} || true
+          fi
 
       - name: Upload report
         uses: actions/upload-artifact@v4

--- a/src/snippets.rs
+++ b/src/snippets.rs
@@ -54,6 +54,7 @@ impl LanguageSnippets {
             "sql" => Self::sql(),
             "lua" => Self::lua(),
             "haskell" => Self::haskell(),
+            "octave" => Self::octave(),
             _ => Self::generic(&lang),
         }
     }
@@ -311,6 +312,27 @@ xcpp::display(h);"#,
             completion_prefix: "testVariableFor",
             display_data_code: "putStrLn \"no rich display\"",
             update_display_data_code: "-- Haskell doesn't support update_display_data",
+        }
+    }
+
+    fn octave() -> Self {
+        // GNU Octave - MATLAB-compatible language
+        Self {
+            language: "octave".to_string(),
+            print_hello: "disp('hello')",
+            print_stderr: "fprintf(2, 'error\\n')",  // fd 2 = stderr in Octave
+            simple_expr: "1 + 1",
+            simple_expr_result: "ans = 2",  // Octave prefixes with "ans = "
+            incomplete_code: "if true",
+            complete_code: "x = 1;",
+            syntax_error: "1 +",
+            input_prompt: "% Octave stdin doesn't support Jupyter input protocol",
+            sleep_code: "pause(2)",
+            completion_var: "test_variable_for_completion",
+            completion_setup: "test_variable_for_completion = 42;",
+            completion_prefix: "test_variable_for_",
+            display_data_code: "% Octave plot() requires display - skip in headless CI",
+            update_display_data_code: "% Octave update_display varies by environment",
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds xeus-octave (xoctave kernel) to the conformance test suite
- Completes issue #30 (final xeus kernel)

## Key Changes
- Use Xvfb (virtual framebuffer) since xeus-octave requires X11/GLFW for graphics
- Add Octave language snippets for MATLAB-compatible syntax
- Skip stdin test (not supported in Jupyter input protocol)

## Note
The original PR #36 had CI triggering issues after several force-pushes. This is a fresh branch.

---
*Submitted on @rgbkrk's behalf by his agent Quill*