### PR TITLE
Fix xeus-haskell kernelspec discovery

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -95,6 +95,10 @@ jobs:
               pixi run -e default prebuild
               pixi run -e default build
               pixi run -e default install
+              # Copy kernelspec from Pixi env to user Jupyter directory
+              mkdir -p ~/.local/share/jupyter/kernels
+              find /tmp/xeus-haskell -path "*share/jupyter/kernels/xhaskell" -exec cp -r {} ~/.local/share/jupyter/kernels/ \; 2>/dev/null || true
+              ls -la ~/.local/share/jupyter/kernels/ || true
             kernel-name: xhaskell
           - name: xeus-octave
             install: micromamba install -y xeus-octave -c conda-forge


### PR DESCRIPTION
## Issue
xeus-haskell tests were running but no report was generated because the kernel wasn't being discovered:
```
Error finding kernel 'xhaskell': Kernel 'xhaskell' not found. Available kernels: []
```

## Fix
The Pixi build installs the kernel inside its environment, not globally. Added step to copy the kernelspec to `~/.local/share/jupyter/kernels/` after the Pixi install.

---
*Submitted on @rgbkrk's behalf by his agent Quill*