### PR TITLE
Fix evcxr display_data with inline trait impl

### DIFF
--- a/src/snippets.rs
+++ b/src/snippets.rs
@@ -119,7 +119,9 @@ impl LanguageSnippets {
             completion_var: "test_variable_for_completion",
             completion_setup: "let test_variable_for_completion = 42;",
             completion_prefix: "test_variable_for_",
-            display_data_code: "// evcxr requires evcxr_display trait impl for display_data",
+            display_data_code: r#"struct Html(&'static str);
+impl Html { fn evcxr_display(&self) { println!("EVCXR_BEGIN_CONTENT text/html\n{}\nEVCXR_END_CONTENT", self.0); } }
+Html("<b>bold</b>").evcxr_display();"#,
             update_display_data_code: "// evcxr doesn't support update_display_data (no display_id)",
         }
     }


### PR DESCRIPTION
## Summary

Fix evcxr (Rust kernel) display_data test by using the evcxr_display pattern:

```rust
struct Html(&'static str);
impl Html { 
    fn evcxr_display(&self) { 
        println!("EVCXR_BEGIN_CONTENT text/html\n{}\nEVCXR_END_CONTENT", self.0); 
    } 
}
Html("<b>bold</b>").evcxr_display();
```

This demonstrates the proper evcxr rich output mechanism documented in [evcxr_jupyter README](https://github.com/evcxr/evcxr/blob/main/evcxr_jupyter/README.md).

## Test plan

- [ ] evcxr display_data test passes (was previously skipped)

_Submitted on @rgbkrk's behalf by his agent Quill_