### PR TITLE
Pin xeus-sql to >=0.3.1 with kernel_info_reply fix

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -61,7 +61,8 @@ jobs:
             install: micromamba install -y xeus-cling -c conda-forge
             kernel-name: xcpp17
           - name: xeus-sql
-            install: micromamba install -y xeus-sql -c conda-forge
+            # Pin to 0.3.1 which includes fix for missing status in kernel_info_reply
+            install: micromamba install -y "xeus-sql>=0.3.1" -c conda-forge
             kernel-name: xsql
           - name: gonb
             install: |


### PR DESCRIPTION
## Summary

Pin xeus-sql to version >=0.3.1 which includes the fix for the missing `status` field in `kernel_info_reply`.

This was the fix we reported upstream and they've now released it.

## Test plan

- [ ] xeus-sql tests continue to pass with the pinned version

_Submitted on @rgbkrk's behalf by his agent Quill_