### PR TITLE
Improve R (ark) snippets based on source code analysis

### DIFF
--- a/src/snippets.rs
+++ b/src/snippets.rs
@@ -101,10 +101,10 @@ impl LanguageSnippets {
             completion_prefix: "test_variable_for_",
             // Ark produces display_data natively for graphics - no IRdisplay needed
             display_data_code: "plot(1:10)",
-            // Note: update_display_data may not trigger in batch mode; Ark may optimize to single render
-            update_display_data_code: "plot(1:10); points(5, 5, col='red', pch=19)",
-            // R doesn't typically produce rich execute_result, uses display_data instead
-            rich_execute_result_code: "// R uses display_data for rich output",
+            // Ark sends update_display_data when a new plot replaces the previous one
+            update_display_data_code: "plot(1:5); Sys.sleep(0.1); plot(6:10)",
+            // Ark returns text/html in execute_result for data frames
+            rich_execute_result_code: "data.frame(x = 1:3, y = c('a', 'b', 'c'))",
         }
     }
 


### PR DESCRIPTION
## Summary

Based on deep research into ark's source code, this PR improves the R kernel snippets:

- **update_display_data**: Fix to trigger actual `update_display_data` by creating separate plots (`plot(1:5); Sys.sleep(0.1); plot(6:10)`) instead of adding points to an existing plot. Ark sends `update_display_data` when a new plot replaces the previous one on the same graphics page (see `graphics_device.rs`).

- **rich_execute_result**: Add support for ark's text/html output in `execute_result` for data frames. Ark returns rich HTML tables for data frames via execute_result, not just via display_data (see `console.rs` `take_result()`).

## Expected Test Result Changes

| Test | Before | After |
|------|--------|-------|
| update_display_data | PARTIAL (0.5) | PASS |
| rich_execute_result | (skipped) | PASS |

## Test plan

- [ ] CI passes
- [ ] ark update_display_data test improves from partial to pass
- [ ] ark rich_execute_result test passes with text/html data frame