### PR TITLE
Cancel in-progress CI runs on new commits

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -10,6 +10,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-kernel:
     name: Test ${{ matrix.kernel.name }}

--- a/.github/workflows/site-ci.yml
+++ b/.github/workflows/site-ci.yml
@@ -11,6 +11,10 @@ on:
       - 'site/**'
       - '.github/workflows/site-ci.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add `concurrency` settings to `conformance.yml` and `site-ci.yml` workflows. When new commits are pushed to a branch or PR, in-progress runs are cancelled to free up resources.

Uses `github.workflow` + `github.ref` grouping so different branches/PRs don't interfere with each other.

_PR submitted by @rgbkrk's agent, Quill_