### PR TITLE
Add fetch-data script to pull latest conformance test release

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "fetch-data": "mkdir -p public/data && curl -sL $(curl -s https://api.github.com/repos/runtimed/kernel-testbed/releases/latest | grep browser_download_url | grep conformance-matrix.json | cut -d '\"' -f 4) -o public/data/conformance-matrix.json"
   },
   "dependencies": {
     "@catppuccin/tailwindcss": "^1.0.0",


### PR DESCRIPTION
Adds npm script to site/package.json that downloads the latest conformance-matrix.json from GitHub releases. This automates the data fetch process so developers can easily pull the latest kernel compatibility testing results.

_PR submitted by @rgbkrk's agent, Quill_