### PR TITLE
Add notebook to display OpenGraph images

### DIFF
--- a/notebooks/og-images.ipynb
+++ b/notebooks/og-images.ipynb
@@ -1,0 +1,210 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from IPython.display import Image, display\n",
+    "\n",
+    "port = os.environ.get('CONDUCTOR_PORT', '8080')\n",
+    "base_url = f\"http://localhost:{port}/kernel-testbed\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Main site OG image\n",
+    "Image(url=f\"{base_url}/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ark (R)\n",
+    "Image(url=f\"{base_url}/kernel/ark/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# deno (TypeScript)\n",
+    "Image(url=f\"{base_url}/kernel/deno/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# gonb (Go)\n",
+    "Image(url=f\"{base_url}/kernel/gonb/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# julia-1.11 (Julia)\n",
+    "Image(url=f\"{base_url}/kernel/julia-1.11/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ocaml-jupyter (OCaml)\n",
+    "Image(url=f\"{base_url}/kernel/ocaml-jupyter/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# python3 (Python)\n",
+    "Image(url=f\"{base_url}/kernel/python3/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# rust (Rust)\n",
+    "Image(url=f\"{base_url}/kernel/rust/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# scala (Scala)\n",
+    "Image(url=f\"{base_url}/kernel/scala/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# xcpp17 (C++17)\n",
+    "Image(url=f\"{base_url}/kernel/xcpp17/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# xcpp20 (C++20)\n",
+    "Image(url=f\"{base_url}/kernel/xcpp20/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# xhaskell (Haskell)\n",
+    "Image(url=f\"{base_url}/kernel/xhaskell/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# xlua (Lua)\n",
+    "Image(url=f\"{base_url}/kernel/xlua/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# xoctave (Octave)\n",
+    "Image(url=f\"{base_url}/kernel/xoctave/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# xpython (Xeus Python)\n",
+    "Image(url=f\"{base_url}/kernel/xpython/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# xr (Xeus R)\n",
+    "Image(url=f\"{base_url}/kernel/xr/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# xsql (Xeus SQL)\n",
+    "Image(url=f\"{base_url}/kernel/xsql/opengraph-image\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# xsqlite (Xeus SQLite)\n",
+    "Image(url=f\"{base_url}/kernel/xsqlite/opengraph-image\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

Added a Jupyter notebook that displays all OpenGraph images generated by the site. Each image is in a separate cell and loads via `IPython.display.Image` using the base path constructed from the `CONDUCTOR_PORT` environment variable.

Includes the main site OG image and all 17 kernel-specific OG images.

_PR submitted by @rgbkrk's agent, Quill_