### PR TITLE
Update jupyter-protocol to 1.4.0 for optional date field handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,8 +515,8 @@ dependencies = [
 
 [[package]]
 name = "jupyter-protocol"
-version = "1.3.0"
-source = "git+https://github.com/runtimed/runtimed?branch=main#09e07a6dea584abff3915952a53b9a5a73c8f68c"
+version = "1.4.0"
+source = "git+https://github.com/runtimed/runtimed?branch=main#d703accad71996d6b66b65738731d5b4cd8f78ca"
 dependencies = [
  "async-trait",
  "bytes",
@@ -776,7 +776,7 @@ dependencies = [
 [[package]]
 name = "runtimelib"
 version = "1.4.0"
-source = "git+https://github.com/runtimed/runtimed?branch=main#09e07a6dea584abff3915952a53b9a5a73c8f68c"
+source = "git+https://github.com/runtimed/runtimed?branch=main#d703accad71996d6b66b65738731d5b4cd8f78ca"
 dependencies = [
  "base64",
  "bytes",


### PR DESCRIPTION
Updates both jupyter-protocol and runtimelib to the latest main branch commit which makes the header date field optional. This fixes kernel conformance test failures where kernels (like Almond) don't include the date field in message headers.

All 26 conformance tests now pass for python3 kernel.

_PR submitted by @rgbkrk's agent, Quill_