### PR TITLE
Generate markdown files and llms.txt during build

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -30,6 +30,7 @@
         "eslint-plugin-react-hooks": "^5.1.0",
         "globals": "^16.5.0",
         "tailwindcss": "^4.2.1",
+        "tsx": "^4.19.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0"
       }
@@ -87,6 +88,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4438,6 +4881,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -5031,6 +5516,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -7780,6 +8280,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/site/package.json
+++ b/site/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && npm run generate-markdown",
+    "generate-markdown": "tsx scripts/generate-markdown.ts",
     "start": "next start",
     "lint": "next lint",
     "fetch-data": "mkdir -p public/data && curl -sL $(curl -s https://api.github.com/repos/runtimed/kernel-testbed/releases/latest | grep browser_download_url | grep conformance-matrix.json | cut -d '\"' -f 4) -o public/data/conformance-matrix.json"
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "tsx": "^4.19.0",
     "@tailwindcss/postcss": "^4.2.1",
     "@types/node": "^24.10.14",
     "@types/react": "^19.2.7",

--- a/site/scripts/generate-markdown.ts
+++ b/site/scripts/generate-markdown.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env tsx
+/**
+ * Generate markdown files from conformance data
+ *
+ * Run after `next build` to generate markdown versions of each page
+ * alongside the HTML output in out/
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ConformanceMatrix } from '../src/types/report.js';
+import {
+  renderSummaryMatrixMarkdown,
+  renderKernelDetailMarkdown,
+  renderLlmsTxt,
+  renderLlmsFullTxt,
+} from '../src/lib/markdown-renderers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const siteDir = path.resolve(__dirname, '..');
+const outDir = path.join(siteDir, 'out');
+const dataPath = path.join(siteDir, 'public/data/conformance-matrix.json');
+
+function ensureDir(dir: string) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function writeFile(filePath: string, content: string) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, content, 'utf-8');
+  console.log(`  ✓ ${path.relative(outDir, filePath)}`);
+}
+
+async function main() {
+  console.log('Generating markdown files...\n');
+
+  // Load conformance data
+  if (!fs.existsSync(dataPath)) {
+    console.error('Error: conformance-matrix.json not found at', dataPath);
+    console.error('Run `npm run fetch-data` first');
+    process.exit(1);
+  }
+
+  const raw = fs.readFileSync(dataPath, 'utf-8');
+  const matrix: ConformanceMatrix = JSON.parse(raw);
+
+  console.log(`Found ${matrix.reports.length} kernel reports\n`);
+
+  // Generate llms.txt
+  writeFile(path.join(outDir, 'llms.txt'), renderLlmsTxt(matrix));
+
+  // Generate llms-full.txt
+  writeFile(path.join(outDir, 'llms-full.txt'), renderLlmsFullTxt(matrix));
+
+  // Generate index.md (summary)
+  writeFile(path.join(outDir, 'index.md'), renderSummaryMatrixMarkdown(matrix));
+
+  // Generate per-kernel markdown files
+  const kernelDir = path.join(outDir, 'kernel');
+  ensureDir(kernelDir);
+
+  for (const report of matrix.reports) {
+    const fileName = `${encodeURIComponent(report.kernel_name)}.md`;
+    writeFile(
+      path.join(kernelDir, fileName),
+      renderKernelDetailMarkdown(report)
+    );
+  }
+
+  console.log(`\nDone! Generated ${3 + matrix.reports.length} files`);
+}
+
+main().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/site/src/lib/markdown-renderers.ts
+++ b/site/src/lib/markdown-renderers.ts
@@ -1,0 +1,333 @@
+/**
+ * Markdown renderer functions that parallel React components
+ *
+ * These generate markdown output using the same data transformation logic
+ * as the React components, enabling React → Markdown content generation.
+ */
+
+import type { ConformanceMatrix, KernelReport, TestCategory, TestRecord } from '@/types/report';
+import {
+  getStatusEmoji,
+  getPassedCount,
+  getTotalCount,
+  getScore,
+  getTierScore,
+  getTierResults,
+  TIER_DESCRIPTIONS,
+  hasStartupError,
+} from '@/types/report';
+import { getKernelMetadata } from './kernel-metadata';
+
+const TIERS: TestCategory[] = ['tier1_basic', 'tier2_interactive', 'tier3_rich_output', 'tier4_advanced'];
+
+/**
+ * Render a score with optional checkmark for perfect scores
+ */
+function renderScore(passed: number, total: number): string {
+  const percentage = total > 0 ? Math.round((passed / total) * 100) : 0;
+  const perfect = passed === total && total > 0;
+  return `${passed}/${total} (${percentage}%)${perfect ? ' ✅' : ''}`;
+}
+
+/**
+ * Group failures by their reason pattern (mirrors FailureSummary component)
+ */
+function groupFailuresByReason(report: KernelReport): Map<string, TestRecord[]> {
+  const groups = new Map<string, TestRecord[]>();
+
+  for (const test of report.results) {
+    if (test.result.status === 'fail') {
+      const reason = test.result.reason || 'Unknown error';
+      const key = reason.includes('Timeout') ? 'Timeout' : reason;
+      const existing = groups.get(key) || [];
+      existing.push(test);
+      groups.set(key, existing);
+    }
+  }
+
+  return groups;
+}
+
+/**
+ * Render failure summary (mirrors FailureSummary component)
+ */
+export function renderFailureSummaryMarkdown(report: KernelReport): string {
+  if (hasStartupError(report)) {
+    return [
+      '### ⚠️ Kernel Failed During Startup',
+      '',
+      'The kernel could not complete initialization. No tests were run.',
+      '',
+      '```',
+      report.startup_error,
+      '```',
+      '',
+      'This usually indicates a fundamental protocol compatibility issue.',
+    ].join('\n');
+  }
+
+  const passed = getPassedCount(report);
+  const total = getTotalCount(report);
+  const failed = total - passed;
+
+  if (failed === 0) {
+    return `### ✅ All Tests Passing\n\n${renderScore(passed, total)}`;
+  }
+
+  const failureGroups = groupFailuresByReason(report);
+  const sortedGroups = Array.from(failureGroups.entries()).sort(
+    (a, b) => b[1].length - a[1].length
+  );
+
+  const lines = [
+    `### ${failed} Test${failed !== 1 ? 's' : ''} Failing`,
+    '',
+    `${passed}/${total} passing (${Math.round((passed / total) * 100)}%)`,
+    '',
+  ];
+
+  for (const [reason, tests] of sortedGroups) {
+    lines.push(`- **${reason}** (${tests.length})`);
+    const testNames = tests.slice(0, 3).map((t) => t.name);
+    if (tests.length > 3) {
+      testNames.push(`+${tests.length - 3} more`);
+    }
+    lines.push(`  - ${testNames.join(', ')}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Render tier breakdown (mirrors TierBreakdown component)
+ */
+export function renderTierBreakdownMarkdown(report: KernelReport): string {
+  const lines: string[] = ['### Test Results by Tier', ''];
+
+  for (const tier of TIERS) {
+    const results = getTierResults(report, tier);
+    if (results.length === 0) continue;
+
+    const [passed, total] = getTierScore(report, tier);
+
+    lines.push(`#### ${TIER_DESCRIPTIONS[tier]} (${passed}/${total})`);
+    lines.push('');
+
+    for (const test of results) {
+      const emoji = getStatusEmoji(test.result.status);
+      lines.push(`${emoji} **${test.name}** - ${test.description}`);
+
+      if (test.result.status === 'fail' && test.result.reason) {
+        lines.push(`   _${test.result.reason}_`);
+      }
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Render kernel card (mirrors KernelCard component)
+ */
+export function renderKernelCardMarkdown(report: KernelReport): string {
+  const passed = getPassedCount(report);
+  const total = getTotalCount(report);
+  const metadata = getKernelMetadata(report.kernel_name);
+
+  const lines: string[] = [
+    `## ${report.kernel_name}`,
+    '',
+  ];
+
+  // Implementation and metadata
+  const impl = metadata?.implementation || report.implementation || report.language;
+  lines.push(`**${impl}** | ${report.language} | Protocol ${report.protocol_version}`);
+  lines.push('');
+
+  if (metadata?.repository) {
+    lines.push(`Repository: ${metadata.repository}`);
+    lines.push('');
+  }
+
+  // Overall score
+  lines.push(`**Score: ${renderScore(passed, total)}**`);
+  lines.push('');
+
+  // Tier summary
+  lines.push('| Tier | Score |');
+  lines.push('|------|-------|');
+  for (const tier of TIERS) {
+    const [tierPassed, tierTotal] = getTierScore(report, tier);
+    if (tierTotal === 0) continue;
+    const perfect = tierPassed === tierTotal ? ' ✅' : '';
+    lines.push(`| ${TIER_DESCRIPTIONS[tier]} | ${tierPassed}/${tierTotal}${perfect} |`);
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+/**
+ * Render full kernel detail page (mirrors kernel/[name]/page.tsx)
+ */
+export function renderKernelDetailMarkdown(report: KernelReport): string {
+  const passed = getPassedCount(report);
+  const total = getTotalCount(report);
+  const metadata = getKernelMetadata(report.kernel_name);
+
+  const lines: string[] = [
+    `# ${report.kernel_name} - Protocol Conformance`,
+    '',
+  ];
+
+  // Header info
+  const impl = metadata?.implementation || report.implementation || report.language;
+  lines.push(`**${impl}** (${report.language}) | Protocol ${report.protocol_version}`);
+  lines.push('');
+
+  if (metadata?.repository) {
+    lines.push(`Repository: ${metadata.repository}`);
+    lines.push('');
+  }
+
+  if (metadata?.description) {
+    lines.push(`> ${metadata.description}`);
+    lines.push('');
+  }
+
+  lines.push(`**Overall Score: ${renderScore(passed, total)}**`);
+  lines.push('');
+
+  // Failure summary
+  lines.push(renderFailureSummaryMarkdown(report));
+  lines.push('');
+
+  // Tier breakdown (only if kernel started successfully)
+  if (!hasStartupError(report)) {
+    lines.push(renderTierBreakdownMarkdown(report));
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Render summary matrix table (mirrors HomeContent/SummaryTable)
+ */
+export function renderSummaryMatrixMarkdown(matrix: ConformanceMatrix): string {
+  const sortedReports = [...matrix.reports].sort((a, b) => {
+    const aScore = getScore(a);
+    const bScore = getScore(b);
+    return bScore - aScore;
+  });
+
+  const lines: string[] = [
+    '# Jupyter Kernel Protocol Conformance',
+    '',
+    `Testing ${matrix.reports.length} kernels against the Jupyter Messaging Protocol.`,
+    '',
+    '| Kernel | Implementation | Score | Tier 1 | Tier 2 | Tier 3 | Tier 4 |',
+    '|--------|---------------|-------|--------|--------|--------|--------|',
+  ];
+
+  for (const report of sortedReports) {
+    const metadata = getKernelMetadata(report.kernel_name);
+    const impl = metadata?.implementation || report.implementation || '-';
+    const passed = getPassedCount(report);
+    const total = getTotalCount(report);
+    const percentage = total > 0 ? Math.round((passed / total) * 100) : 0;
+
+    const tierScores = TIERS.map((tier) => {
+      const [p, t] = getTierScore(report, tier);
+      if (t === 0) return '-';
+      return `${p}/${t}`;
+    });
+
+    lines.push(
+      `| ${report.kernel_name} | ${impl} | ${percentage}% | ${tierScores.join(' | ')} |`
+    );
+  }
+
+  lines.push('');
+  lines.push(`_Generated: ${new Date(matrix.generated_at).toISOString().split('T')[0]}_`);
+
+  return lines.join('\n');
+}
+
+/**
+ * Render llms.txt overview file
+ */
+export function renderLlmsTxt(matrix: ConformanceMatrix): string {
+  const sortedReports = [...matrix.reports].sort((a, b) => {
+    const aScore = getScore(a);
+    const bScore = getScore(b);
+    return bScore - aScore;
+  });
+
+  const lines: string[] = [
+    '# Jupyter Kernel Protocol Conformance Testbed',
+    '',
+    'Automated protocol compliance testing for Jupyter kernels against the',
+    'Jupyter Messaging Protocol specification.',
+    '',
+    'https://runtimed.github.io/kernel-testbed/',
+    '',
+    `## Tested Kernels (${matrix.reports.length})`,
+    '',
+    '| Kernel | Implementation | Language | Score |',
+    '|--------|---------------|----------|-------|',
+  ];
+
+  for (const report of sortedReports) {
+    const metadata = getKernelMetadata(report.kernel_name);
+    const impl = metadata?.implementation || report.implementation || '-';
+    const passed = getPassedCount(report);
+    const total = getTotalCount(report);
+    const percentage = total > 0 ? Math.round((passed / total) * 100) : 0;
+    const perfect = passed === total && total > 0 ? ' ✅' : '';
+
+    lines.push(`| ${report.kernel_name} | ${impl} | ${report.language} | ${percentage}%${perfect} |`);
+  }
+
+  lines.push('');
+  lines.push('## Links');
+  lines.push('');
+  lines.push('- Full results: /kernel-testbed/llms-full.txt');
+  lines.push('- Summary matrix: /kernel-testbed/index.md');
+  lines.push('- Per-kernel reports: /kernel-testbed/kernel/{name}.md');
+  lines.push('');
+  lines.push(`_Generated: ${new Date(matrix.generated_at).toISOString().split('T')[0]}_`);
+
+  return lines.join('\n');
+}
+
+/**
+ * Render llms-full.txt with all kernel reports concatenated
+ */
+export function renderLlmsFullTxt(matrix: ConformanceMatrix): string {
+  const sortedReports = [...matrix.reports].sort((a, b) => {
+    const aScore = getScore(a);
+    const bScore = getScore(b);
+    return bScore - aScore;
+  });
+
+  const lines: string[] = [
+    '# Jupyter Kernel Protocol Conformance - Full Results',
+    '',
+    `Testing ${matrix.reports.length} kernels against the Jupyter Messaging Protocol.`,
+    '',
+    '---',
+    '',
+  ];
+
+  for (const report of sortedReports) {
+    lines.push(renderKernelDetailMarkdown(report));
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+  }
+
+  lines.push(`_Generated: ${new Date(matrix.generated_at).toISOString().split('T')[0]}_`);
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
Add parallel markdown renderers that mirror React components to generate static .md files for each page alongside HTML. Build now runs markdown generation after Next.js build, producing:

- **llms.txt** - Overview table with all kernels and scores
- **llms-full.txt** - Complete conformance data concatenated per-kernel
- **index.md** - Summary matrix
- **kernel/*.md** - Per-kernel detail pages (17 files)

Renderers reuse data transformation logic from report.ts helper functions for consistency.

_PR submitted by @rgbkrk's agent, Quill_