### PR TITLE
Add copy button and clarify repo link text

### DIFF
--- a/site/app/kernel/[name]/page.tsx
+++ b/site/app/kernel/[name]/page.tsx
@@ -4,8 +4,10 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { Header } from '@/components/Header';
 import { TierBreakdown } from '@/components/TierBreakdown';
 import { FailureSummary } from '@/components/FailureSummary';
+import { CopyMarkdownButton } from '@/components/CopyMarkdownButton';
 import { getConformanceData, getAllKernelNames, getKernelReport } from '@/lib/data';
 import { getKernelMetadata } from '@/lib/kernel-metadata';
+import { renderKernelDetailMarkdown } from '@/lib/markdown-renderers';
 import { getPassedCount, getTotalCount, hasStartupError } from '@/types/report';
 import { notFound } from 'next/navigation';
 
@@ -56,6 +58,7 @@ export default async function KernelPage({ params }: KernelPageProps) {
   }
 
   const metadata = getKernelMetadata(report.kernel_name);
+  const markdownContent = renderKernelDetailMarkdown(report);
 
   return (
     <TooltipProvider>
@@ -75,18 +78,21 @@ export default async function KernelPage({ params }: KernelPageProps) {
             <p className="text-ctp-subtext0">
               {report.implementation} ({report.language}) • Protocol {report.protocol_version}
             </p>
-            {metadata?.repository && (
-              <a
-                href={metadata.repository}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 text-sm text-ctp-blue hover:text-ctp-sapphire transition-colors mt-2"
-              >
-                <Github className="h-4 w-4" />
-                View on GitHub
-                <ExternalLink className="h-3 w-3" />
-              </a>
-            )}
+            <div className="flex items-center gap-4 mt-2">
+              {metadata?.repository && (
+                <a
+                  href={metadata.repository}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-sm text-ctp-blue hover:text-ctp-sapphire transition-colors"
+                >
+                  <Github className="h-4 w-4" />
+                  View Official Repo on GitHub
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              )}
+              <CopyMarkdownButton content={markdownContent} />
+            </div>
           </div>
 
           <FailureSummary report={report} />

--- a/site/src/components/CopyMarkdownButton.tsx
+++ b/site/src/components/CopyMarkdownButton.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+
+interface CopyMarkdownButtonProps {
+  content: string;
+}
+
+export function CopyMarkdownButton({ content }: CopyMarkdownButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="inline-flex items-center gap-1.5 text-sm text-ctp-subtext0 hover:text-ctp-text transition-colors"
+      title="Copy as Markdown"
+    >
+      {copied ? (
+        <>
+          <Check className="h-4 w-4 text-ctp-green" />
+          <span className="text-ctp-green">Copied!</span>
+        </>
+      ) : (
+        <>
+          <Copy className="h-4 w-4" />
+          <span>Copy as Markdown</span>
+        </>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
Add CopyMarkdownButton component to kernel detail pages allowing users to copy the page's markdown representation with a single click. The button shows visual feedback (checkmark) for 2 seconds after copying. Also improved link text from 'View on GitHub' to 'View Official Repo on GitHub' for clarity about which repository is being linked.

_PR submitted by @rgbkrk's agent, Quill_