### PR TITLE
Add Octave input request

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -196,7 +196,7 @@
       "incomplete_code": "if true",
       "complete_code": "x = 1;",
       "syntax_error": "1 +",
-      "input_prompt": "% Octave stdin doesn't support Jupyter input protocol",
+      "input_prompt": "name = input(\"Enter: \")",
       "sleep_code": "pause(2)",
       "completion_var": "test_variable_for_completion",
       "completion_setup": "test_variable_for_completion = 42;",

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -701,7 +701,11 @@ fn test_stdin_input_request(
             return TestResult::Unsupported;
         }
 
-        let mock_input = "test_input_42";
+        // Mock input includes quotes to ensure validity in languages like
+        // GNU Octave, where unquoted undefined variables (e.g. `test_input_42`)
+        // would cause a kernel error.
+        // TODO: Make mock input language-dependent for robustness.
+        let mock_input = "\"test_input_42\"";
 
         match kernel.execute_with_stdin(&code, mock_input).await {
             Ok((reply, _iopub, received_input_request)) => {


### PR DESCRIPTION
`test_input_42` is not a valid mock input for GNU Octave, which causes the test failure.

![input](https://github.com/user-attachments/assets/b7475be8-ce3b-4b62-95f5-f5459d7505a4)

The input string should be a valid Octave expression, like `"hello"` or `1`, but just typing `hello` will trigger an error if the `hello` variable is not defined.