### PR TITLE
Post conformance PR comment via workflow_run

### DIFF
--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -1,0 +1,32 @@
+name: Comment PR with Conformance Results
+
+on:
+  workflow_run:
+    workflows: ["Kernel Conformance"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    name: Post conformance summary
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download PR comment artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          PR=$(cat pr_number.txt)
+          gh pr comment "$PR" --body-file summary.md

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -391,11 +391,19 @@ jobs:
             done
           } | tee -a $GITHUB_STEP_SUMMARY > summary.md
 
-      - name: Comment on PR
+      - name: Save PR number for comment workflow
         if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh pr comment ${{ github.event.pull_request.number }} --body-file summary.md
+        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+
+      - name: Upload PR comment payload
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-comment
+          path: |
+            summary.md
+            pr_number.txt
+          if-no-files-found: error
 
       - name: Upload combined reports
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Fork PRs receive a read-only `GITHUB_TOKEN` regardless of the top-level `permissions` block, so the inline `gh pr comment` step in `conformance.yml` fails with `Resource not accessible by integration (addComment)` whenever a contributor opens a PR from a fork (e.g. #84).
- Move commenting into a separate `comment-on-pr.yml` workflow triggered by `workflow_run`, which runs in the base-repo context with `pull-requests: write` and only reads the uploaded summary artifact — it never checks out PR code.
- `conformance.yml` now writes `pr_number.txt` and uploads `summary.md` + the PR number as a `pr-comment` artifact when the event is a PR.

## Caveat
`workflow_run` only reads workflow files from the default branch, so the comment workflow won't fire for this PR itself — it'll start working on PRs opened after this lands on `main`.

## Test plan
- [ ] Merge to `main`
- [ ] Have a fork-based PR opened (or re-push #84) and confirm the conformance summary comment is posted by the `Comment PR with Conformance Results` workflow
- [ ] Confirm the `Kernel Conformance` workflow still posts the step summary and uploads the `conformance-reports` artifact